### PR TITLE
Rename MockFixture to MockerFixture in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,7 +184,7 @@ the method, and uses pytest's own `advanced assertions`_ to return a better
 diff::
 
 
-    mocker = <pytest_mock.MockFixture object at 0x0381E2D0>
+    mocker = <pytest_mock.MockerFixture object at 0x0381E2D0>
 
         def test(mocker):
             m = mocker.Mock()


### PR DESCRIPTION
My test crashed for an `ImportError` when update to `3.3.0`.

```python
E   ModuleNotFoundError: No module named 'oscc'
```

There is a change from `MockFixture` to `MockerFixture`, for type annotations.

https://github.com/pytest-dev/pytest-mock/commit/23440707423518d665721ff896be60ae6dc283f0

But I have use it for a long time. I think the old name is also worth to exist for several versions with a deprecation warning.

When I read README for the latest guide, I find this old class name.

